### PR TITLE
Friend trees for semileptonic channels and first attempt of a 1l selection

### DIFF
--- a/RootTools/python/samples/samples_13TeV_RunIIAutumn18NanoAODv7.py
+++ b/RootTools/python/samples/samples_13TeV_RunIIAutumn18NanoAODv7.py
@@ -416,16 +416,27 @@ VHToNonbb, #VHToNonbb_ll,
 # === PRIVATE SAMPLES
 
 # === DI-BOSONOS + TOP + JET
-TJWW_1L = kreator.makeMCComponentFromEOS("TJWW_1L", "/TJWW_1L/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/user/emanuele/hwh/nanoaod/2018/",".*pp-tjww-1l.*root",0.00299)
-TJWW_2L = kreator.makeMCComponentFromEOS("TJWW_2L", "/TJWW_2L/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/user/emanuele/hwh/nanoaod/2018/",".*pp-tjww-2l.*root",0.000506)
-TJWZ    = kreator.makeMCComponentFromEOS("TJWZ",    "/TJWZ/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM",   "/store/user/emanuele/hwh/nanoaod/2018/",".*pp-tjwz.*root",   0.00566)
-TJZZ    = kreator.makeMCComponentFromEOS("TJZZ",    "/TJZZ/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM",   "/store/user/emanuele/hwh/nanoaod/2018/",".*pp-tjzz.*root",   0.000517)
+TJWpWm_SM_2018 = kreator.makeMCComponentFromEOS("TJWpWm_SM_2018", "/TJWpWm_SM_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWpWm_SM_2018.*root",0.000805)
+TJWpWp_SM_2018 = kreator.makeMCComponentFromEOS("TJWpWp_SM_2018", "/TJWpWp_SM_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWpWp_SM_2018.*root",0.00118)
+TJWZ_SM_2018 = kreator.makeMCComponentFromEOS("TJWZ_SM_2018", "/TJWZ_SM_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWZ_SM_2018.*root",0.000729)
+TJZZ_SM_2018 = kreator.makeMCComponentFromEOS("TJZZ_SM_2018", "/TJZZ_SM_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJZZ_SM_2018.*root",8.72e-5)
+
+# cross sections are copies of the SM ones, cannot find them in the MG output, to be changed at the plot level
+TJWpWm_0p8_2018 = kreator.makeMCComponentFromEOS("TJWpWm_0p8_2018", "/TJWpWm_0p8_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWpWm_0p8_2018.*root",0.000805)
+TJWpWp_0p8_2018 = kreator.makeMCComponentFromEOS("TJWpWp_0p8_2018", "/TJWpWp_0p8_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWpWp_0p8_2018.*root",0.00118)
+TJWZ_0p8_2018 = kreator.makeMCComponentFromEOS("TJWZ_0p8_2018", "/TJWZ_0p8_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWZ_0p8_2018.*root",0.000729)
+TJZZ_0p8_2018 = kreator.makeMCComponentFromEOS("TJZZ_0p8_2018", "/TJZZ_0p8_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJZZ_0p8_2018.*root",8.72e-5)
+
 
 TJXs = [
-    TJWW_1L,
-    TJWW_2L,
-    TJWZ,
-    TJZZ,
+    TJWpWm_SM_2018,
+    TJWpWp_SM_2018,
+    TJWZ_SM_2018,
+    TJZZ_SM_2018,
+    TJWpWm_0p8_2018,
+    TJWpWp_0p8_2018,
+    TJWZ_0p8_2018,
+    TJZZ_0p8_2018,    
 ]
 
 # ----------------------------- summary ----------------------------------------

--- a/TTHAnalysis/cfg/run_HwH_fromNanoAOD_cfg.py
+++ b/TTHAnalysis/cfg/run_HwH_fromNanoAOD_cfg.py
@@ -71,7 +71,13 @@ if analysis == "main":
         # other Higgs processes
         "GGHZZ4L", "VHToNonbb", "VHToNonbb_ll", "ZHTobb_ll", "ZHToTauTau", "TTWH", "TTZH",
         # tj + dibosons
-        "TJWW_1L","TJWW_2L","TJWZ","TJZZ",
+        "TJWpWm_SM_2018","TJWZ_SM_2018","TJZZ_SM_2018",
+        "TJWpWm_0p8_2018","TJWZ_0p8_2018",
+    ]])
+    mcSignal = byCompName(mcSamples_, ["%s(|_PS)$"%dset for dset in [
+        # tj + dibosons
+        "TJWpWm_SM_2018","TJWpWp_SM_2018","TJWZ_SM_2018","TJZZ_SM_2018",
+        "TJWpWm_0p8_2018","TJWpWp_0p8_2018","TJWZ_0p8_2018","TJZZ_0p8_2018",
     ]])
     DatasetsAndTriggers.append( ("DoubleMuon", triggerGroups_dict["Trigger_2m"][year] + triggerGroups_dict["Trigger_3m"][year]) )
     DatasetsAndTriggers.append( ("EGamma",     triggerGroups_dict["Trigger_2e"][year] + triggerGroups_dict["Trigger_3e"][year] + triggerGroups_dict["Trigger_1e"][year]) if year == 2018 else
@@ -114,6 +120,8 @@ if getHeppyOption('selectComponents'):
         selectedComponents = mcSamples
     elif getHeppyOption('selectComponents')=='DATA':
         selectedComponents = dataSamples
+    elif getHeppyOption('selectComponents')=='signalMC':
+        selectedComponents = mcSignal
     else:
         selectedComponents = byCompName(selectedComponents, getHeppyOption('selectComponents').split(","))
 autoAAA(selectedComponents, quiet=not(getHeppyOption("verboseAAA",False)), redirectorAAA="xrootd-cms.infn.it")
@@ -282,12 +290,12 @@ elif test == "102X-MC":
     W1JetsToLNu_LO = kreator.makeMCComponent("W1JetsToLNu_LO","/W1JetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM", "CMS", ".*root", 8123*1.17)
     W1JetsToLNu_LO.files = [ 'root://cms-xrd-global.cern.ch//store/mc/RunIIAutumn18NanoAODv7/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/NANOAODSIM/Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/260000/93250E4A-9D02-854F-9CD6-80A0172FDCC1.root' ]
 
-    TJWW_1L = kreator.makeMCComponentFromEOS("TJWW_1L", "/TJWW_1L/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/user/emanuele/hwh/nanoaod/2018/",".*pp-tjww-1l.*root",0.00299)
-    TJWW_1L.files = [ '/eos/cms/store/user/emanuele/hwh/nanoaod/2018/pp-tjww-1l.root' ]
+    TJWpWm_SM_2018 = kreator.makeMCComponentFromEOS("TJWpWm_SM_2018", "/TJWpWm_SM_2018/RunIIAutumn18NanoAODv7-Nano02Apr2020_102X_upgrade2018_realistic_v21-v1/NANOAODSIM","/store/cmst3/group/wmass/secret/signalNanoAOD/",".*TJWpWm_SM_2018.*root",0.000805)
+    TJWpWm_SM_2018.files = [ '/eos/cms/store/cmst3/group/wmass/secret/signalNanoAOD/TJWpWm_SM_2018.root' ]
 
-    localfile = os.path.expandvars("/tmp/$USER/%s" % os.path.basename(TJWW_1L.files[0]))
-    if os.path.exists(localfile): TJWW_1L.files = [ localfile ] 
-    selectedComponents = [TJWW_1L]
+    localfile = os.path.expandvars("/tmp/$USER/%s" % os.path.basename(TJWpWm_SM_2018.files[0]))
+    if os.path.exists(localfile): TJWpWm_SM_2018.files = [ localf5Dile ] 
+    selectedComponents = [TJWpWm_SM_2018]
 
 elif test in ('2','3','3s'):
     doTestN(test, selectedComponents)

--- a/TTHAnalysis/macros/prepareEventVariablesFriendTree.py
+++ b/TTHAnalysis/macros/prepareEventVariablesFriendTree.py
@@ -189,8 +189,8 @@ if options.checkchunks:
         size = int(fields[4])
         fname = fields[8]
         basepattern = options.outPattern % r"(\w+)"
-        m1 = re.match(basepattern + r"%s.chunk(\d+).sub(\d+).root" % (), fname);
-        m2 = re.match(basepattern + r"%s.chunk(\d+).root", fname);
+        m1 = re.match(basepattern + r".chunk(\d+).sub(\d+).root", fname);
+        m2 = re.match(basepattern + r".chunk(\d+).root", fname);
         good = (size > 2048)
         if m1:
             sample = m1.group(1)
@@ -383,7 +383,7 @@ Error      = {logdir}/err.$(cluster).$(Dataset).$({chunk})
 Output     = {logdir}/out.$(cluster).$(Dataset).$({chunk})
 Log        = {logdir}/log.$(cluster).$(Dataset).$({chunk})
 
-use_x509userproxy = $ENV(X509_USER_PROXY)
+use_x509userproxy = True
 getenv = True
 request_memory = 2000
 +MaxRuntime = {maxruntime}

--- a/TTHAnalysis/python/plotter/hwh/1lnj.txt
+++ b/TTHAnalysis/python/plotter/hwh/1lnj.txt
@@ -1,0 +1,12 @@
+alwaystrue: 1
+#trigger: Trigger_2lss
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+ptl25: LepGood1_pt>25
+Tight: LepGood1_isLepTight_Recl
+exclusive: nLepTight_Recl<=1
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 250
+nV: nVJetSel_Recl >= 1
+ptV: VJetSel_Recl_pt[0] >= 50 
+1fwdj: nLJetSel_Recl >= 1 
+tauveto: nTauSel_Recl==0

--- a/TTHAnalysis/python/plotter/hwh/1lnj.txt
+++ b/TTHAnalysis/python/plotter/hwh/1lnj.txt
@@ -3,10 +3,10 @@ alwaystrue: 1
 filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
 ptl25: LepGood1_pt>25
 Tight: LepGood1_isLepTight_Recl
-exclusive: nLepTight_Recl<=1
+exclusive 1l: nLepTight_Recl<=1
 nT: nTJetSel_Recl >= 1
 ptT: TJetSel_Recl_pt[0] > 250
 nV: nVJetSel_Recl >= 1
-ptV: VJetSel_Recl_pt[0] >= 50 
+ptV: VJetSel_Recl_pt[0] >= 150 
 1fwdj: nLJetSel_Recl >= 1 
 tauveto: nTauSel_Recl==0

--- a/TTHAnalysis/python/plotter/hwh/mca-1l-mc.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-1l-mc.txt
@@ -1,0 +1,2 @@
+incl_sigprompt : + ; IncludeMca="hwh/mca-includes/mca-1l-sigprompt.txt"
+#incl_mcfakes   : + ; IncludeMca="hwh/mca-includes/mca-1l-mcfakes.txt"

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-1l-sigprompt.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-1l-sigprompt.txt
@@ -1,0 +1,3 @@
+tqWpWm+   : TJWpWm_SM_2018.root : xsec ; FillColor=ROOT.kOrange+10
+                                                                                                                                                      
+

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-1l-sigprompt.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-1l-sigprompt.txt
@@ -1,3 +1,4 @@
-tqWpWm+   : TJWpWm_SM_2018.root : xsec ; FillColor=ROOT.kOrange+10
+tqWpWm+   : TJWpWm_SM_2018 : xsec ; FillColor=ROOT.kOrange+10
+tqWpWm+   : TJWpWp_SM_2018 : xsec ; FillColor=ROOT.kOrange+10
                                                                                                                                                       
 

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -349,7 +349,7 @@ class TreeToYield:
             friendOpts += [ ('Friends', d+"/{cname}_Friend.root") for d in friendSimpleOpts]
         else:
             friendOpts += [ ('sf/t', d+"/evVarFriend_{cname}.root") for d in friendSimpleOpts]
-        return [ (tname,fname.format(name=self._name, cname=self._cname, P=self._basepath)) for (tname,fname) in friendOpts ]
+        return [ (tname,fname.format(name=self._name, cname=self._cname.replace('.root',''), P=self._basepath)) for (tname,fname) in friendOpts ]
     def checkFriendTrees(self, checkFiles=False):
         ok = True
         for (tn,fn) in self._listFriendTrees():

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -349,7 +349,7 @@ class TreeToYield:
             friendOpts += [ ('Friends', d+"/{cname}_Friend.root") for d in friendSimpleOpts]
         else:
             friendOpts += [ ('sf/t', d+"/evVarFriend_{cname}.root") for d in friendSimpleOpts]
-        return [ (tname,fname.format(name=self._name, cname=self._cname.replace('.root',''), P=self._basepath)) for (tname,fname) in friendOpts ]
+        return [ (tname,fname.format(name=self._name, cname=self._cname, P=self._basepath)) for (tname,fname) in friendOpts ]
     def checkFriendTrees(self, checkFiles=False):
         ok = True
         for (tn,fn) in self._listFriendTrees():

--- a/TTHAnalysis/python/tools/nanoAOD/ttH_modules.py
+++ b/TTHAnalysis/python/tools/nanoAOD/ttH_modules.py
@@ -148,10 +148,11 @@ from CMGTools.TTHAnalysis.tools.hjDummCalc import HjDummyCalc
 hjDummy = lambda : HjDummyCalc(variations  = [ 'jes%s'%v for v in jecGroups] + ['jer%s'%x for x in ['barrel','endcap1','endcap2highpt','endcap2lowpt' ,'forwardhighpt','forwardlowpt']  ]  + ['HEM'])
 
 from CMGTools.TTHAnalysis.tools.objTagger import ObjTagger
+from PhysicsTools.NanoAODTools.postprocessing.modules.gen.genFriendProducer import genFriends
 isMatchRightCharge = lambda : ObjTagger('isMatchRightCharge','LepGood', [lambda l,g : (l.genPartFlav==1 or l.genPartFlav == 15) and (g.pdgId*l.pdgId > 0) ], linkColl='GenPart',linkVar='genPartIdx')
 mcMatchId     = lambda : ObjTagger('mcMatchId','LepGood', [lambda l : (l.genPartFlav==1 or l.genPartFlav == 15) ])
 mcPromptGamma = lambda : ObjTagger('mcPromptGamma','LepGood', [lambda l : (l.genPartFlav==22)])
-mcMatch_seq   = [ isMatchRightCharge, mcMatchId ,mcPromptGamma]
+mcMatch_seq   = [ genFriends, isMatchRightCharge, mcMatchId ,mcPromptGamma]
 
 countTaus = lambda : ObjTagger('Tight','TauSel_Recl', [lambda t : t.idDeepTau2017v2p1VSjet&4])
 


### PR DESCRIPTION
* on the recleaner added the collections of boosted top, hadronic V and light jets (cleaned in this order, after cleaning leptons)
* for the friend trees, changed few things here and there to run
* first snapshot of 1l selection (tested on t j w+w- SM signal only)

