### PR TITLE
MC truth decay finder in the friend trees and mca/txt with selections

### DIFF
--- a/TTHAnalysis/python/plotter/hwh/1l_tight.txt
+++ b/TTHAnalysis/python/plotter/hwh/1l_tight.txt
@@ -1,0 +1,15 @@
+alwaystrue: 1
+trigger: Trigger_1e || Trigger_1m || Trigger_2lss || Trigger_3l
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+ptl25: LepGood1_pt>25
+Tight: LepGood1_isLepTight_Recl
+exclusive: nLepTight_Recl<=1 
+
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 250
+nV: nVJetSel_Recl >= 1
+ptV: VJetSel_Recl_pt[0] >= 100 
+#mV: VJetSel_Recl_mass[0]>50 && VJetSel_Recl_mass[0]<100
+
+#5j: nJet25_Recl>=5
+1B: nBJetMedium25_Recl<=1

--- a/TTHAnalysis/python/plotter/hwh/2l_tight.txt
+++ b/TTHAnalysis/python/plotter/hwh/2l_tight.txt
@@ -1,0 +1,17 @@
+alwaystrue: 1
+trigger: Trigger_2lss
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+dilep: nLepFO_Recl>=2
+cleanup: minMllAFAS > 12
+pt2515: LepGood1_conePt>25 && LepGood2_conePt>15
+TT: LepGood1_isLepTight_Recl && LepGood2_isLepTight_Recl
+exclusive: nLepTight_Recl==2
+#same-sign: LepGood1_charge*LepGood2_charge > 0
+#Zee_veto: abs(LepGood1_pdgId)!=11 || abs(LepGood2_pdgId) != 11 || abs(mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2_pt,LepGood2_eta,LepGood2_phi,LepGood2_mass)-91.2) > 10
+#Z_veto: abs(mZ1-91.2)>10
+eleID: (abs(LepGood1_pdgId)!=11 || (LepGood1_convVeto && LepGood1_lostHits==0 && LepGood1_tightCharge>=2)) && (abs(LepGood2_pdgId)!=11 || (LepGood2_convVeto && LepGood2_lostHits==0 && LepGood2_tightCharge>=2))
+muTightCharge: (abs(LepGood1_pdgId)!=13 || LepGood1_tightCharge>=1) && (abs(LepGood2_pdgId)!=13 || LepGood2_tightCharge>=1)
+
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 150
+1fwdj: nLJetSel_Recl >= 1 

--- a/TTHAnalysis/python/plotter/hwh/2lss_tight.txt
+++ b/TTHAnalysis/python/plotter/hwh/2lss_tight.txt
@@ -1,0 +1,62 @@
+alwaystrue: 1
+trigger: Trigger_2lss
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+cleanup: minMllAFAS > 12
+dilep: nLepFO_Recl>=2
+pt2515: LepGood1_conePt>25 && LepGood2_conePt>15
+#htllv100 : LepGood1_conept+LepGood2_conept+MET_pt > 100
+TT: LepGood1_isLepTight_Recl && LepGood2_isLepTight_Recl
+exclusive: nLepTight_Recl<=2
+same-sign: LepGood1_charge*LepGood2_charge > 0
+Zee_veto: abs(LepGood1_pdgId)!=11 || abs(LepGood2_pdgId) != 11 || abs(mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2_pt,LepGood2_eta,LepGood2_phi,LepGood2_mass)-91.2) > 10
+#metLDee: abs(LepGood1_pdgId)!=11 || abs(LepGood2_pdgId) != 11 || MET_pt*0.6 + mhtJet25*0.4 > 30
+Z_veto: abs(mZ1-91.2)>10
+eleID: (abs(LepGood1_pdgId)!=11 || (LepGood1_convVeto && LepGood1_lostHits==0 && LepGood1_tightCharge>=2)) && (abs(LepGood2_pdgId)!=11 || (LepGood2_convVeto && LepGood2_lostHits==0 && LepGood2_tightCharge>=2))
+muTightCharge: (abs(LepGood1_pdgId)!=13 || LepGood1_tightCharge>=1) && (abs(LepGood2_pdgId)!=13 || LepGood2_tightCharge>=1)
+
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 250
+1B: nBJetMedium25_Recl<=1
+
+#4j: nJet25_Recl>=4
+#2b1B: nBJetLoose25_Recl >= 2 || nBJetMedium25_Recl >= 1
+#tauveto: nTauTight_Recl==0
+
+# some cuts that are off by default but can be turned on with -E
+tightMVA070: LepGood1_mvaTTH>0.70 && LepGood2_mvaTTH>0.70 ; Disable=True
+tightMVA075: LepGood1_mvaTTH>0.75 && LepGood2_mvaTTH>0.75 ; Disable=True
+tightMVA080: LepGood1_mvaTTH>0.80 && LepGood2_mvaTTH>0.80 ; Disable=True
+tightMVA085: LepGood1_mvaTTH>0.85 && LepGood2_mvaTTH>0.85 ; Disable=True
+tightMVA090: LepGood1_mvaTTH>0.90 && LepGood2_mvaTTH>0.90 ; Disable=True
+tightMVA095: LepGood1_mvaTTH>0.95 && LepGood2_mvaTTH>0.95 ; Disable=True
+1B: nBJetMedium25 >= 1 ; Disable=True
+2B: nBJetMedium25 >= 2 ; Disable=True
+BLoose: nBJetMedium25 < 2 ; Disable=True
+BTight: nBJetMedium25 >= 2 ; Disable=True
+2j: nJet25>=2 ; Disable=True
+x3j: nJet25==3 ; Disable=True
+6j: nJet25>=6 ; Disable=True
+
+ee: abs(LepGood1_pdgId)==11 && abs(LepGood2_pdgId)==11; Disable=True
+em: abs(LepGood1_pdgId) != abs(LepGood2_pdgId);         Disable=True
+mm: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13; Disable=True
+mll200: mass_2(LepGood1_conePt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2_conePt,LepGood2_eta,LepGood2_phi,LepGood2_mass)>200; Disable=True
+b2lss_ee: abs(LepGood1_pdgId)==11 && abs(LepGood2_pdgId)==11 ; Disable=True
+b2lss_ee_neg: abs(LepGood1_pdgId)==11 && abs(LepGood2_pdgId)==11 && LepGood1_charge<0 ; Disable=True
+b2lss_ee_pos: abs(LepGood1_pdgId)==11 && abs(LepGood2_pdgId)==11 && LepGood1_charge>0 ; Disable=True
+b2lss_em: (abs(LepGood1_pdgId) != abs(LepGood2_pdgId)) ; Disable=True
+b2lss_em_bl_neg: (abs(LepGood1_pdgId) != abs(LepGood2_pdgId)) && LepGood1_charge<0 && nBJetMedium25 < 2 ; Disable=True
+b2lss_em_bl_pos: (abs(LepGood1_pdgId) != abs(LepGood2_pdgId)) && LepGood1_charge>0 && nBJetMedium25 < 2 ; Disable=True
+b2lss_em_bt_neg: (abs(LepGood1_pdgId) != abs(LepGood2_pdgId)) && LepGood1_charge<0 && nBJetMedium25 >= 2 ; Disable=True
+b2lss_em_bt_pos: (abs(LepGood1_pdgId) != abs(LepGood2_pdgId)) && LepGood1_charge>0 && nBJetMedium25 >= 2 ; Disable=True
+b2lss_mm: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13 ; Disable=True
+b2lss_mm_bl_neg: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13 && LepGood1_charge<0 && nBJetMedium25 < 2 ; Disable=True
+b2lss_mm_bl_pos: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13 && LepGood1_charge>0 && nBJetMedium25 < 2 ; Disable=True
+b2lss_mm_bt_neg: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13 && LepGood1_charge<0 && nBJetMedium25 >= 2 ; Disable=True
+b2lss_mm_bt_pos: abs(LepGood1_pdgId)==13 && abs(LepGood2_pdgId)==13 && LepGood1_charge>0 && nBJetMedium25 >= 2 ; Disable=True
+b2lss_bl: nBJetMedium25 < 2 ; Disable=True
+b2lss_bt: nBJetMedium25 >= 2 ; Disable=True
+2lep_promptrightcharge: (!isData) && LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge; Disable=True
+fakeIsMu : if3((nLepFO>1)*(LepGood1_isLepTight+LepGood2_isLepTight==1),if3(LepGood1_isLepTight,(abs(LepGood2_pdgId)==13),(abs(LepGood1_pdgId)==13)),0); Disable=True
+fakeIsEl : if3((nLepFO>1)*(LepGood1_isLepTight+LepGood2_isLepTight==1),if3(LepGood1_isLepTight,(abs(LepGood2_pdgId)==11),(abs(LepGood1_pdgId)==11)),0); Disable=True
+muChargeConsistencyThree: (abs(LepGood1_pdgId)!=13 || LepGood1_chargeConsistency>=3) && (abs(LepGood2_pdgId)!=13 || LepGood2_chargeConsistency>=3); Disable=True

--- a/TTHAnalysis/python/plotter/hwh/3l_tight.txt
+++ b/TTHAnalysis/python/plotter/hwh/3l_tight.txt
@@ -1,0 +1,15 @@
+alwaystrue: 1
+trilep: nLepFO_Recl>=3
+exclusive: nLepTight_Recl <= 3
+cleanup: minMllAFAS > 12
+trigger: Trigger_3l
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+pt251515: LepGood1_conePt>25 && LepGood2_conePt>15 && LepGood3_conePt>10
+TTT: LepGood1_isLepTight_Recl && LepGood2_isLepTight_Recl && LepGood3_isLepTight_Recl
+q1: abs(LepGood1_charge + LepGood2_charge + LepGood3_charge) == 1
+
+ele conv cuts: (abs(LepGood1_pdgId)!=11 || (LepGood1_convVeto && LepGood1_lostHits==0)) && (abs(LepGood2_pdgId)!=11 || (LepGood2_convVeto && LepGood2_lostHits==0)) && (abs(LepGood3_pdgId)!=11 || (LepGood3_convVeto && LepGood3_lostHits==0))
+
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 150
+1fwdj: nLJetSel_Recl >= 1 

--- a/TTHAnalysis/python/plotter/hwh/4l_tight.txt
+++ b/TTHAnalysis/python/plotter/hwh/4l_tight.txt
@@ -1,0 +1,12 @@
+alwaystrue: 1
+trilep: nLepFO_Recl>=4
+cleanup: minMllAFAS > 12
+trigger: Trigger_3l
+filters: Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && (Flag_ecalBadCalibFilter || (year == 2016))  $DATA{&& Flag_eeBadScFilter}
+pt25151510: LepGood1_conePt>25 && LepGood2_conePt>15 && LepGood3_conePt>15 && LepGood4_conePt>10
+TTTT: LepGood1_isLepTight_Recl && LepGood2_isLepTight_Recl && LepGood3_isLepTight_Recl && LepGood4_isLepTight_Recl
+ele conv cuts: (abs(LepGood1_pdgId)!=11 || (LepGood1_convVeto && LepGood1_lostHits==0)) && (abs(LepGood2_pdgId)!=11 || (LepGood2_convVeto && LepGood2_lostHits==0)) && (abs(LepGood3_pdgId)!=11 || (LepGood3_convVeto && LepGood3_lostHits==0)) && (abs(LepGood4_pdgId)!=11 || (LepGood4_convVeto && LepGood4_lostHits==0))
+
+nT: nTJetSel_Recl >= 1
+ptT: TJetSel_Recl_pt[0] > 150
+1fwdj: nLJetSel_Recl >= 1 

--- a/TTHAnalysis/python/plotter/hwh/mca-2l-mc.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-2l-mc.txt
@@ -1,0 +1,2 @@
+incl_sigprompt : + ; IncludeMca="hwh/mca-includes/mca-2l-sigprompt-splitdecays.txt"
+#incl_mcfakes   : + ; IncludeMca="hwh/mca-includes/mca-2l-mcfakes.txt"

--- a/TTHAnalysis/python/plotter/hwh/mca-3l-mc.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-3l-mc.txt
@@ -1,0 +1,2 @@
+incl_sigprompt : + ; IncludeMca="hwh/mca-includes/mca-3l-sigprompt-splitdecays.txt"
+#incl_mcfakes   : + ; IncludeMca="hwh/mca-includes/mca-3l-mcfakes.txt"

--- a/TTHAnalysis/python/plotter/hwh/mca-4l-mc.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-4l-mc.txt
@@ -1,0 +1,2 @@
+incl_sigprompt : + ; IncludeMca="hwh/mca-includes/mca-4l-sigprompt.txt"
+#incl_mcfakes   : + ; IncludeMca="hwh/mca-includes/mca-4l-mcfakes.txt"

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-2l-sigprompt-splitdecays.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-2l-sigprompt-splitdecays.txt
@@ -1,0 +1,25 @@
+tqWpWm_Wlep+        : TJWpWm_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWm_Wsemilep+    : TJWpWm_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp_Wlep+        : TJWpWp_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp_Wsemilep+    : TJWpWp_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ_Vlep+          : TJWZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ_Vsemilep+      : TJWZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode<=1 || GenV2DecayMode<=1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ_Vlep+          : TJZZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ_Vsemilep+      : TJZZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+
+#TT	: TTJets_DiLepton_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+#TT   	: TTJets_SingleLeptonFromT_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+#TT   	: TTJets_SingleLeptonFromTbar_part9 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+
+#T : T_sch_lep+T_sch_lep_PS : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2016\,2017"
+#T : T_sch_lep              : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2018"
+#T : T_tch                  : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2016\,2018"
+#T : T_tch+T_tch_PS         : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2017"
+
+#TTW     : TTWToLNu_fxfx   : 0.1960 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kGreen-5, genSumWeightName="genEventSumw", Label="ttW   ", years="2016\,2018"
+#TTZ     : TTZToLLNuNu_amc : 0.281 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw", Label="ttZ ", years="2016\,2018"
+
+#WZ     : WZTo3LNu_fxfx : 4.43 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4, genSumWeightName="genEventSumw"
+#ZZ     : ZZTo4L : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4, genSumWeightName="genEventSumw"
+
+#Rares: TZQToLL : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years= "2017\,2018"

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-2l-sigprompt.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-2l-sigprompt.txt
@@ -1,0 +1,21 @@
+tqWpWm+   : TJWpWm_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp+   : TJWpWp_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ+     : TJWZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ+     : TJZZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+
+TT	: TTJets_DiLepton_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+TT   	: TTJets_SingleLeptonFromT_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+TT   	: TTJets_SingleLeptonFromTbar_part9 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw"
+
+#T : T_sch_lep+T_sch_lep_PS : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2016\,2017"
+#T : T_sch_lep              : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2018"
+#T : T_tch                  : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2016\,2018"
+#T : T_tch+T_tch_PS         : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years="2017"
+
+#TTW     : TTWToLNu_fxfx   : 0.1960 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kGreen-5, genSumWeightName="genEventSumw", Label="ttW   ", years="2016\,2018"
+#TTZ     : TTZToLLNuNu_amc : 0.281 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kSpring+2, genSumWeightName="genEventSumw", Label="ttZ ", years="2016\,2018"
+
+#WZ     : WZTo3LNu_fxfx : 4.43 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4, genSumWeightName="genEventSumw"
+#ZZ     : ZZTo4L : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4, genSumWeightName="genEventSumw"
+
+#Rares: TZQToLL : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, genSumWeightName="genEventSumw", years= "2017\,2018"

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-3l-sigprompt-splitdecays.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-3l-sigprompt-splitdecays.txt
@@ -1,0 +1,27 @@
+tqWpWm_Wlep+        : TJWpWm_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWm_Wsemilep+    : TJWpWm_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp_Wlep+        : TJWpWp_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp_Wsemilep+    : TJWpWp_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ_Vlep+          : TJWZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ_Vsemilep+      : TJWZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode<=1 || GenV2DecayMode<=1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ_Vlep+          : TJZZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode>1  && GenV2DecayMode>1 ); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ_Vsemilep+      : TJZZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && (GenV1DecayMode<=1 || GenV2DecayMode<=1); FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+
+
+#TT	: TTJets_DiLepton_part8 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+#TT   	: TTJets_SingleLeptonFromT_part7 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+#TT   	: TTJets_SingleLeptonFromTbar_part3 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+
+#T : T_sch_lep+T_sch_lep_PS : xsec :   LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2017"
+#T : T_sch_lep_part1        : xsec :   LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2018"
+#T : T_tch_part3            : 136.02+80.95 :   LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2018"
+#T : T_tch+T_tch_PS         : 136.02+80.95 :   LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2017"
+
+#TTW     : TTWToLNu_fxfx_part2 : 0.1960 : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ;  FillColor=ROOT.kGreen-5, Label="ttW   ", years="2016\,2018"
+#TTZ     : TTZToLLNuNu_amc : 0.281 : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ;  FillColor=ROOT.kSpring+2, Label="ttZ ", years="2016\,2018"
+
+#WZ     : WZTo3LNu_fxfx_part1 : 4.43 : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ;  FillColor=ROOT.kViolet-4
+#ZZ     : ZZTo4L : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ;  FillColor=ROOT.kViolet-4
+
+#Rares: TZQToLL_part1 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0 ; FillColor=ROOT.kAzure-9, years= "2017\,2018"
+

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-3l-sigprompt.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-3l-sigprompt.txt
@@ -1,0 +1,22 @@
+tqWpWm+   : TJWpWm_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp+   : TJWpWp_SM_2018 : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ+     : TJWZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ+     : TJZZ_SM_2018   : xsec : LepGood1_mcMatchId!=0 && LepGood2_mcMatchId!=0 && LepGood3_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+
+TT	: TTJets_DiLepton_part8 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2
+TT   	: TTJets_SingleLeptonFromT_part7 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2
+TT   	: TTJets_SingleLeptonFromTbar_part3 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kSpring+2
+
+T : T_sch_lep+T_sch_lep_PS : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2017"
+T : T_sch_lep_part1        : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2018"
+T : T_tch_part3            : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2018"
+T : T_tch+T_tch_PS         : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2017"
+
+#TTW     : TTWToLNu_fxfx_part2 : 0.1960 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kGreen-5, Label="ttW   ", years="2016\,2018"
+#TTZ     : TTZToLLNuNu_amc : 0.281 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kSpring+2, Label="ttZ ", years="2016\,2018"
+
+WZ     : WZTo3LNu_fxfx_part1 : 4.43 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4
+ZZ     : ZZTo4L : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ;  FillColor=ROOT.kViolet-4
+
+Rares: TZQToLL_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years= "2017\,2018"
+

--- a/TTHAnalysis/python/plotter/hwh/mca-includes/mca-4l-sigprompt.txt
+++ b/TTHAnalysis/python/plotter/hwh/mca-includes/mca-4l-sigprompt.txt
@@ -1,0 +1,26 @@
+tqWpWm+   : TJWpWm_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWpWp+   : TJWpWp_SM_2018 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqWZ+     : TJWZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+tqZZ+     : TJZZ_SM_2018   : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0; FillColor=ROOT.kOrange+10, genSumWeightName="genEventSumw_"
+
+TT	: TTJets_DiLepton_part8 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+TT   	: TTJets_SingleLeptonFromT_part7 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+TT   	: TTJets_SingleLeptonFromTbar_part3 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ; FillColor=ROOT.kSpring+2
+
+T : T_sch_lep+T_sch_lep_PS : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2017"
+T : T_sch_lep_part1        : xsec :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2018"
+T : T_tch_part3            : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2016\,2018"
+T : T_tch+T_tch_PS         : 136.02+80.95 :   LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 && LepGood2_isMatchRightCharge ; FillColor=ROOT.kAzure-9, years="2017"
+
+#TTW     : TTWToLNu_fxfx_part2 : 0.1960 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ;  FillColor=ROOT.kGreen-5, Label="ttW   ", years="2016\,2018"
+#TTZ     : TTZToLLNuNu_amc : 0.281 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ;  FillColor=ROOT.kSpring+2, Label="ttZ ", years="2016\,2018"
+
+WZ     : WZTo3LNu_fxfx_part1 : 4.43 : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ;  FillColor=ROOT.kViolet-4
+ZZ     : ZZTo4L : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ;  FillColor=ROOT.kViolet-4
+
+Rares: TZQToLL_part1 : xsec : LepGood1_isMatchRightCharge && LepGood2_isMatchRightCharge && LepGood3_mcMatchId!=0 && LepGood4_mcMatchId!=0 ; FillColor=ROOT.kAzure-9, years= "2017\,2018"
+
+
+
+                                                                                                                                                      
+

--- a/TTHAnalysis/python/tools/nanoAOD/hwhDecayFinder.py
+++ b/TTHAnalysis/python/tools/nanoAOD/hwhDecayFinder.py
@@ -1,0 +1,101 @@
+from PhysicsTools.NanoAODTools.postprocessing.framework.eventloop import Module
+from PhysicsTools.NanoAODTools.postprocessing.framework.datamodel import Collection 
+
+
+class hwhDecayFinder( Module ): 
+    def __init__(self, lepCollection="LepGood", genCollection="GenPart"):
+        self.lepCollection = lepCollection
+        self.genCollection = genCollection
+
+    def beginFile(self, inputFile, outputFile, inputTree, wrappedOutputTree):
+        self.out = wrappedOutputTree
+        self.out.branch('GenTopDecayMode','I')
+        self.out.branch('GenV1DecayMode','I')
+        self.out.branch('GenV2DecayMode','I')
+        self.out.branch('nLepGood','I')
+        self.out.branch('LepGood_genAncestor','I', lenVar='nLepGood')
+
+    def getTopDecay(self, idx, genParts):
+        decayproducts = [] 
+        for g in genParts:
+            if g.genPartIdxMother == idx:
+                if abs(g.pdgId) == 6 or abs(g.pdgId) == 24:
+                    return self.getTopDecay(genParts.index(g),genParts)
+                else:
+                    decayproducts.append( abs(g.pdgId) )
+        if len(decayproducts) > 2: print "More than two top decay products?", decayproducts
+        if not len(decayproducts): print 'No top decay products found...'
+        return decayproducts
+
+    def getPromptVDecay(self, idx, genParts):
+        decayproducts = [] 
+        for g in genParts:
+            if g.genPartIdxMother == idx: 
+                if (abs(g.pdgId) in [23,24]):
+                    return self.getPromptVDecay( genParts.index(g),genParts)
+                else: 
+                    decayproducts.append( abs(g.pdgId) )
+        if len(decayproducts) > 2: print "More than two V decay products?", decayproducts
+        if not len(decayproducts): print 'No V decay products found...'
+        return decayproducts
+
+    def getLeptonAncestor(self, idx, genParts):
+        ancestor = -1
+        if idx>0: 
+            for g in genParts:
+                if genParts.index(g) == idx:
+                    if g.genPartIdxMother > 0:
+                        return self.getLeptonAncestor( g.genPartIdxMother, genParts)
+                    elif g.genPartIdxMother==0 and (g.statusFlags>>7)&1==1:
+                        ancestor = g.pdgId
+                    else:
+                        break
+            #if ancestor == -1: print "No lepton ancestor found?"
+        return ancestor
+
+    def analyze(self, event):
+        leps = [ l for l in Collection(event, self.lepCollection) ]
+        genParts = [ g for g in Collection(event, self.genCollection) ]
+        promptVDecays = []
+        topDecay = None
+        ancestors = []
+
+        # look for the TVV decay chain
+        for g in genParts:
+            if abs(g.pdgId) in [23,24] and g.genPartIdxMother==0:
+                promptVDecay = self.getPromptVDecay(genParts.index(g), genParts)
+                promptVDecays.append(promptVDecay)
+            elif abs(g.pdgId) == 6 and g.genPartIdxMother==0:
+                topDecay = self.getTopDecay(genParts.index(g), genParts)
+        
+        if not topDecay:  
+            self.out.fillBranch('GenTopDecayMode',-1);
+        elif   topDecay == [11,12] or topDecay == [12,11] : 
+            self.out.fillBranch('GenTopDecayMode',11);
+        elif   topDecay == [13,14] or topDecay == [14,13] : 
+            self.out.fillBranch('GenTopDecayMode',13);
+        elif   topDecay == [15,16] or topDecay == [16,15] : 
+            self.out.fillBranch('GenTopDecayMode',15);
+        else:  
+            self.out.fillBranch('GenTopDecayMode',1);
+
+        for v,vDecay in enumerate(promptVDecays):
+            if   vDecay == [11,12] or vDecay == [12,11] :
+                self.out.fillBranch('GenV%dDecayMode'%(v+1),11)
+            elif vDecay == [13,14] or vDecay == [14,13] : 
+                self.out.fillBranch('GenV%dDecayMode'%(v+1),13);
+            elif vDecay == [15,16] or vDecay == [16,15] : 
+                self.out.fillBranch('GenV%dDecayMode'%(v+1),15);
+            else:
+                self.out.fillBranch('GenV%dDecayMode'%(v+1),1);
+
+        # look for the ancestors of the matched leptons
+        for l in leps:
+            idxGen = l.genPartIdx
+            ancestor = self.getLeptonAncestor(idxGen, genParts)
+            ancestors.append(ancestor)
+        self.out.fillBranch("LepGood_genAncestor", ancestors)
+
+        return True
+
+        


### PR DESCRIPTION
Adding  MC truth labels to distinguish signal decay tree. Something strange happening with WZ (never finding fully lep Z decay, to be checked).

the selection is just thrown, to be redefined with the updated boosted top definition 
@mdunser 